### PR TITLE
Issue 3 concurrent futures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,152 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintainted in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/kintro/connect.py
+++ b/kintro/connect.py
@@ -12,6 +12,7 @@ import click
 @click.pass_context
 def account(ctx, user, password, server):
 
+    ctx.obj['logger'].info(f'Connecting to plex via account({user}) and password')
     account = MyPlexAccount(user, password)
     ctx.obj['plex'] = account.resource(server).connect()
 
@@ -21,6 +22,7 @@ def account(ctx, user, password, server):
 @click.pass_context
 def server(ctx, url, token):
 
+    ctx.obj['logger'].info(f'Connecting to plex via url({url}) and token')
     ctx.obj['plex'] = PlexServer(url, token)
 
 account.add_command(sync)

--- a/kintro/decisions.py
+++ b/kintro/decisions.py
@@ -1,6 +1,8 @@
-DECISION_TYPES = {
-    'cut': 0,
-    'mute': 1,
-    'scene': 2,
-    'commercial': 3
-}
+import enum
+
+@enum.unique
+class DECISION_TYPES(enum.Enum):
+    cut = 0
+    mute = 1
+    scene = 2
+    commercial = 3

--- a/kintro/kintro.py
+++ b/kintro/kintro.py
@@ -2,15 +2,29 @@ from kintro.connect import account, server
 from kintro.utils import _init_logger
 
 import click
+import logging
 
 
 @click.group()
 @click.version_option()
+@click.option(
+    '--log-level',
+    default='info',
+    type=click.Choice(['debug', 'info', 'warning', 'error']),
+    help='Set the minimum log level'
+)
 @click.pass_context
-def cli(ctx):
+def cli(ctx, log_level):
+
+    log_level = {
+        'debug': logging.DEBUG,
+        'info': logging.INFO,
+        'warning': logging.WARNING,
+        'error': logging.ERROR,
+    }[log_level.lower()]
 
     ctx.obj = {}
-    ctx.obj['logger'] = _init_logger('kintro')
+    ctx.obj['logger'] = _init_logger('kintro', log_level)
 
 cli.add_command(account)
 cli.add_command(server)

--- a/kintro/kintro.py
+++ b/kintro/kintro.py
@@ -25,6 +25,7 @@ def cli(ctx, log_level):
 
     ctx.obj = {}
     ctx.obj['logger'] = _init_logger('kintro', log_level)
+    ctx.obj['debug'] = log_level == logging.DEBUG
 
 cli.add_command(account)
 cli.add_command(server)

--- a/kintro/plex.py
+++ b/kintro/plex.py
@@ -1,17 +1,30 @@
 from click_option_group import optgroup, AllOptionGroup
 from kintro.decisions import DECISION_TYPES
 
+import collections
+import concurrent.futures
 import click
 import enum
+import functools
 import itertools
 import json
+import more_itertools
 import os
+from plexapi.video import Episode
+import queue
+import threading
+import time
+from typing import (
+    Deque,
+    List,
+)
 
 
 @enum.unique
 class LibType(enum.Enum):
     Episode = 'episode'
     Show = 'show'
+
 
 @click.command()
 @click.option('--library', required=True, default='TV Shows', help='Plex library to operate on')
@@ -46,11 +59,15 @@ class LibType(enum.Enum):
 )
 @optgroup.option('--find-path', help='Find string')
 @optgroup.option('--replace-path', type=click.Path(exists=True), help='Replace directory')
+@click.option('--max-workers', default=4, help='Max Number of workers to process episodes')
+@click.option('--worker-batch-size', default=10, help='Chunk of work to hand off to each worker')
 @click.pass_context
-def sync(ctx, library, edit, dry_run, libtype, filter_json, find_path, replace_path):
+def sync(ctx, library, edit, dry_run, libtype, filter_json, find_path, replace_path, max_workers, worker_batch_size):
+    ctx.obj['logger'].info('Starting sync process')
 
     plex = ctx.obj['plex']
     libtype = LibType(libtype.lower())
+    edit = DECISION_TYPES[edit]
 
     more_search = {'filters': json.loads(filter_json)} if filter_json is not None else {}
     tv = {
@@ -59,29 +76,179 @@ def sync(ctx, library, edit, dry_run, libtype, filter_json, find_path, replace_p
             *(show.episodes() for show in plex.library.section(library).search(libtype='show', **more_search))),
     }[libtype]()
 
-    for episode in tv:
-        if episode.hasIntroMarker:
-            # multiple markers can exist for a file. only want type intro,
-            # but it's possible there could be more than one intro
-            decisions = []
-            for marker in episode.markers:
-                if marker.type == 'intro':
-                    start = marker.start / 1000
-                    end = marker.end / 1000
-                    # build the content for the file
-                    intro_entry = '%s %s %s' % (start, end, DECISION_TYPES[edit])
-                    # plex can expose multiple locations for a video/episode, so we should
-                    # iterate through them and write an .edl file for each
-                    for location in episode.locations:
-                        file_path = os.path.splitext(location)[0] + '.edl'
-                        # if we're running in a container or otherwise need to fix the path
-                        if find_path:
-                            file_path = file_path.replace(find_path, replace_path)
-                        if not dry_run:
-                            with open(file_path, 'w') as writer:
-                                writer.write(intro_entry)
-                        ctx.obj['logger'].info(
-                            'show="%s" season=%s episode=%s title="%s" location="%s start=%s end=%s file="%s"' %
-                            (episode.grandparentTitle, episode.seasonNumber, episode.episodeNumber,
-                             episode.title, episode.locations, start, end, file_path)
-                        )
+    if max_workers == 1:
+        for episode in (tv if worker_batch_size == 1 else itertools.chain.from_iterable(more_itertools.ichunked(tv, worker_batch_size))):
+            handle_episode(
+                ctx=ctx,
+                episode=episode,
+                edit=edit,
+                find_path=find_path,
+                replace_path=replace_path,
+                dry_run=dry_run,
+            )
+    else:
+        # Break the TV into yielding iterator chunks for batch processing
+        tv_chunked = more_itertools.ichunked(tv, worker_batch_size)
+
+        # Queues for interthread batches and results
+        batch_queue = collections.deque()
+        results = collections.deque()
+        # Events controlling if processing threads are allowed to start or stop
+        start_event = threading.Event()
+        stop_event = threading.Event()
+
+        def submit():
+            ctx.obj['logger'].debug('Putting all episodes in batched queue')
+            for episodes in tv_chunked:
+                ctx.obj['logger'].debug(f'Putting chunk of episodes in batched queue')
+                batch_queue.append(episodes)
+                start_event.set()
+                time.sleep(0.01)
+            start_event.set()
+            ctx.obj['logger'].debug('Sending stop event')
+            stop_event.set()
+
+        # Start the submitter in a background thread
+        ctx.obj['logger'].debug(f'Starting submitter background thread')
+        submitter = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        submitter_res = submitter.submit(submit)
+
+        ctx.obj['logger'].debug(f'Starting processing pool with max #{max_workers} workers and batch size {worker_batch_size}')
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+
+        # Bind all the non varying args for the worker function
+        handle_eps = functools.partial(
+            handle_episodes,
+            ctx=ctx,
+            edit=edit,
+            find_path=find_path,
+            replace_path=replace_path,
+            dry_run=dry_run,
+            episodes_source=batch_queue,
+            results_sink=results,
+            start_event=start_event,
+            stop_event=stop_event,
+        )
+
+        ctx.obj['logger'].debug(f'Starting worker fucntions on pool threads (#{max_workers})')
+        res = executor.map(
+            handle_eps,
+            [x for x in range(0, max_workers)],
+        )
+
+
+        ctx.obj['logger'].debug('Requesting the submitter be destroyed')
+        submitter.shutdown()
+        ctx.obj['logger'].debug('Requesting the worker pool be destroyed')
+        executor.shutdown()
+
+        if ctx.obj['debug']:
+            try:
+                for r in res:
+                    ctx.obj['logger'].debug(f'Worker thread launch result: {r}')
+            except Exception as e:
+                ctx.obj['logger'].exception(f'Error while checking worker thread status {e}')
+
+            try:
+                ctx.obj['logger'].debug(f'Submitter thread status {submitter_res.result()}')
+            except Exception as e:
+                ctx.obj['logger'].exception(f'Error while checking submitter thread status {e}')
+            
+            while True:
+                ctx.obj['logger'].debug('Looping on results')
+                try:
+                    result = results.pop()
+                    if len(result) > 0:
+                        ctx.obj['logger'].debug(result)
+                except IndexError:
+                    break;
+
+
+def handle_episodes(
+    ix,
+    *,
+    episodes_source: Deque[List[Episode]],
+    results_sink: Deque[List[str]],
+    start_event: threading.Event,
+    stop_event: threading.Event,
+    ctx,
+    edit: DECISION_TYPES,
+    find_path: str,
+    replace_path: str,
+    dry_run: bool,
+) -> List[List[str]]:
+    ctx.obj['logger'].info(f'Starting a episodes thread {threading.current_thread().name}')
+    ctx.obj['logger'].debug(f'Waiting for start event on thread {threading.current_thread().name}')
+    start_event.wait()
+    ctx.obj['logger'].debug(f'Done Waiting for start event on thread {threading.current_thread().name}')
+    while True:
+        try:
+            episodes = list(episodes_source.pop())
+            ctx.obj['logger'].debug(f'Starting a batch of {len(episodes)} episodes on thread {threading.current_thread().name}')
+            for episode in episodes:
+                results_sink.append(
+                    handle_episode(
+                        ctx=ctx,
+                        episode=episode,
+                        edit=edit,
+                        find_path=find_path,
+                        replace_path=replace_path,
+                        dry_run=dry_run,
+                    ),
+                )
+        except IndexError as e:
+            if stop_event.is_set():
+                break
+            ctx.obj['logger'].debug(f'Nothing in queue to process in {threading.current_thread().name} continuing in 1 second')
+            time.sleep(1)
+        except Exception as e:
+            ctx.obj['logger'].warning(f'Exception {e} in {threading.current_thread().name} continuing')
+            continue
+    return None
+
+
+def handle_episode(
+    ctx,
+    episode: Episode,
+    edit: DECISION_TYPES,
+    find_path: str,
+    replace_path: str,
+    dry_run: bool,
+) -> List[str]:
+    files_to_modify = []
+
+    ctx.obj['logger'].debug(
+        'Checking for intro marker show="%s" season=%s episode=%s title="%s"' %
+        (episode.grandparentTitle, episode.seasonNumber, episode.episodeNumber,
+         episode.title)
+    )
+    # This call is EXTREMELY expensive, do not prefilter on it (this lets threads bear the weight)
+    if episode.hasIntroMarker:
+        # multiple markers can exist for a file. only want type intro,
+        # but it's possible there could be more than one intro
+        for marker in episode.markers:
+            if marker.type == 'intro':
+                start = marker.start / 1000
+                end = marker.end / 1000
+                # build the content for the file
+                intro_entry = '%s %s %s' % (start, end, edit.value)
+                # plex can expose multiple locations for a video/episode, so we should
+                # iterate through them and write an .edl file for each
+                for location in episode.locations:
+                    file_path = os.path.splitext(location)[0] + '.edl'
+                    # if we're running in a container or otherwise need to fix the path
+                    if find_path:
+                        file_path = file_path.replace(find_path, replace_path)
+                    if not dry_run:
+                        with open(file_path, 'w') as writer:
+                            writer.write(intro_entry)
+
+                    files_to_modify.append(file_path)
+
+                    ctx.obj['logger'].info(
+                        'show="%s" season=%s episode=%s title="%s" location="%s start=%s end=%s file="%s"' %
+                        (episode.grandparentTitle, episode.seasonNumber, episode.episodeNumber,
+                         episode.title, episode.locations, start, end, file_path)
+                    )
+
+    return files_to_modify

--- a/kintro/utils.py
+++ b/kintro/utils.py
@@ -2,18 +2,18 @@ import logging
 import sys
 
 
-def _init_logger(name):
+def _init_logger(name, log_level):
     formatter = logging.Formatter(
         fmt=(
             '%(asctime)s %(filename)-15s %(funcName)-20s '
-            '%(levelname)-7s %(message)s'
+            '(%(threadName)-23s) %(levelname)-7s %(message)s'
         ),
         datefmt='%Y-%m-%d %H:%M:%S'
     )
     screen_handler = logging.StreamHandler(stream=sys.stdout)
     screen_handler.setFormatter(formatter)
     logger = logging.getLogger(name)
-    logger.setLevel(logging.INFO)
+    logger.setLevel(log_level)
     logger.addHandler(screen_handler)
 
     return logger

--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,5 @@ setup(
     packages=['kintro'],
     keywords=['kodi', 'plex' 'intro'],
     classifiers=[],
-    install_requires=['click', 'click_option_group', 'plexapi']
+    install_requires=['click', 'click_option_group', 'plexapi', 'more_itertools>=7.1.0']
 )


### PR DESCRIPTION
This PR allows the user to pass in `--max-workers` as `int` defaulting to `4` and `--worker-batch-size` as `int` defaulting to `10` to make the processing happen in some background threads. I mostly tested with values of `10` and `100` respectively, but left the defaults lower for less powerful machines.

The implementation uses a extra single thread to submit work to a deque that is read from the worker threads cooperatively.
It additionally uses a series of `threading.Event`s to ensure the readiness and eradication of the background threads.

It has a special case for `max_workers == 1` to eskew the overhead of launching threads in the trivial case 

`--worker-batch-size` is used to control how granular the background threads reads from the queue are to allow the effectiveness to be tuned.

Additionally added some logging level tuning via `--log-level` defaulting to `info`. And spattered a bunch of debug / other logging.